### PR TITLE
Add prototype to Vue tutorial

### DIFF
--- a/tutorial/simple-todos/01-creating-app.md
+++ b/tutorial/simple-todos/01-creating-app.md
@@ -11,8 +11,8 @@ Install the latest official Meteor release [following the steps in our docs](htt
 
 The easiest way to setup Meteor with Vue is by using the command `meteor create` with the option `--vue` and your project name:
 
-```
-meteor create --vue simple-todos-vue
+```bash
+meteor create --vue simple-todos-vue --prototype
 ```
 
 Meteor will create all the necessary files for you. 


### PR DESCRIPTION
in 2.9 insecure will need to be added manually, in order for this tutorial not to be outdated, I will adjust its creation by passing the --prototype flag as shown in the [pr](https://github.com/meteor/meteor/pull/12220)
