### PR TITLE
Update 01-creating-app.md - (change --vue2 to --vue-2)

### DIFF
--- a/tutorial/simple-todos/01-creating-app.md
+++ b/tutorial/simple-todos/01-creating-app.md
@@ -9,13 +9,13 @@ Install the latest official Meteor release [following the steps in our docs](htt
 
 ## 1.2: Create Meteor Project
 
-The easiest way to setup Meteor with Vue is by using the command `meteor create` with the option `--vue2` and your project name:
+The easiest way to setup Meteor with Vue is by using the command `meteor create` with the option `--vue-2` and your project name:
 
 
-> Side note: Since meteorJS version 2.9 the default --vue will create a vue3 app, in order to follow this tutorial, use the vue2 command: ``--vue2``
+> Side note: Since meteorJS version 2.9 the default --vue will create a vue3 app, in order to follow this tutorial, use the vue2 command: ``--vue-2``
 
 ```
-meteor create --vue2 simple-todos-vue --prototype
+meteor create --vue-2 simple-todos-vue --prototype
 ```
 
 Meteor will create all the necessary files for you. 


### PR DESCRIPTION
When running the command `meteor create --vue2 simple-todos-vue --prototype`, it returns `--vue2: unknown option.` The fix here is that the option should be `--vue-2`.