### PR TITLE
Fix: Fixed the docs for correct installation link

### DIFF
--- a/tutorial/simple-todos/01-creating-app.md
+++ b/tutorial/simple-todos/01-creating-app.md
@@ -5,7 +5,7 @@ title: "1: Creating the app"
 ## 1.1: Install Meteor
 First we need to install Meteor.
 
-Install the latest official Meteor release [following the steps in our docs](https://docs.meteor.com/install.html).
+Install the latest official Meteor release [following the steps in our docs](https://docs.meteor.com/about/install.html).
 
 ## 1.2: Create Meteor Project
 


### PR DESCRIPTION
This PR aims at displaying the correct installation link in the vue tutorial documentation in "install meteor" segment in the "Creating the App" section of the tutorial
Linked Issue: [13334](https://github.com/meteor/meteor/issues/13334)